### PR TITLE
Fix error with MyISAM in Azure Database for MySQL

### DIFF
--- a/maintenance/tables.sql
+++ b/maintenance/tables.sql
@@ -1179,7 +1179,8 @@ CREATE TABLE /*_*/searchindex (
 
   -- Munged version of body text
   si_text mediumtext NOT NULL
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) /*$wgDBTableOptions*/;
+-- former line was: ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 CREATE UNIQUE INDEX /*i*/si_page ON /*_*/searchindex (si_page);
 CREATE FULLTEXT INDEX /*i*/si_title ON /*_*/searchindex (si_title);


### PR DESCRIPTION
Using this mediawiki version from the Azure marketplace creates an error during the instalation in Azure Database for MySQL because it only supports InnoDB and this file mandates searchindex to be created with MyISAM

Given that latest version supports fulltext index all tables can be created with InnoDB.